### PR TITLE
Fixes a syntax error

### DIFF
--- a/bashfblib.sh
+++ b/bashfblib.sh
@@ -68,4 +68,3 @@ fblib_cleanup()
 {
 	rm ${TEMP}
 }
-}


### PR DESCRIPTION
You accidentally duplicated the closing brace of the `fblib_cleanup()` function ;)
